### PR TITLE
Add signers to `create`

### DIFF
--- a/packages/solana-client/src/GTransaction.ts
+++ b/packages/solana-client/src/GTransaction.ts
@@ -7,7 +7,8 @@ import { Base58, Solana } from "./base-types";
 import { FixableGlowBorsh } from "./borsh/base";
 import { GlowBorshTypes } from "./borsh/GlowBorshTypes";
 import { TRANSACTION_MESSAGE } from "./borsh/transaction-borsh";
-import { GKeypair } from "./GKeypair";
+
+export type Signer = { secretKey: Buffer | Uint8Array };
 
 /**
  * This is useful for manipulating existing transactions for a few reasons:
@@ -76,7 +77,7 @@ export namespace GTransaction {
     instructions: InstructionFactory[];
     recentBlockhash: string;
     feePayer?: string;
-    signers?: Array<GKeypair>;
+    signers?: Array<Signer>;
   }): GTransaction => {
     const accountMap: Record<
       Solana.Address,
@@ -164,7 +165,7 @@ export namespace GTransaction {
     gtransaction,
   }: {
     gtransaction: GTransaction;
-    signers: Array<GKeypair>;
+    signers: Array<Signer>;
   }): GTransaction => {
     for (const { secretKey } of signers) {
       const keypair = nacl.sign.keyPair.fromSecretKey(secretKey);

--- a/packages/solana-client/src/__tests__/GTransaction.test.ts
+++ b/packages/solana-client/src/__tests__/GTransaction.test.ts
@@ -254,7 +254,7 @@ describe("GTransaction", () => {
     transaction.partialSign(from as unknown as Keypair);
     gTransaction = GTransaction.sign({
       gtransaction: gTransaction,
-      secretKey: from.secretKey,
+      signers: [from],
     });
 
     // Verify that serialized transactions with more signatures are equal too

--- a/packages/solana-client/src/__tests__/GTransaction.test.ts
+++ b/packages/solana-client/src/__tests__/GTransaction.test.ts
@@ -308,6 +308,142 @@ describe("GTransaction", () => {
     );
   });
 
+  test("create with signing with obsolete signers", async () => {
+    // Prepare a simple transfer transaction
+    const from = GKeypair.generate();
+    // We need static to since we match error message against obsolete signer address
+    const to = GKeypair.fromSecretKey(
+      bs58.decode(
+        "2EhQ3g6KrXfPrK8ad5Aa4aCXxKWoGaFD5jRq8ADQxnZ6xr9PxaYj81KtJBseDGudomTPYvEPt2rn8bKpHtcYYtFc"
+      )
+    );
+    const ix = SystemProgram.transfer({
+      fromPubkey: from.publicKey as unknown as PublicKey,
+      toPubkey: to.publicKey as unknown as PublicKey,
+      lamports: 5_000 * 1.5,
+    });
+
+    const transaction = new Transaction({
+      feePayer: from.publicKey as unknown as PublicKey,
+      recentBlockhash: GPublicKey.default.toBase58(),
+    });
+    transaction.add(ix);
+
+    expect(() => {
+      GTransaction.create({
+        recentBlockhash: GPublicKey.default.toBase58(),
+        feePayer: from.address,
+        instructions: [
+          {
+            accounts: ix.keys.map(({ pubkey, isSigner, isWritable }) => ({
+              address: pubkey.toBase58(),
+              signer: isSigner,
+              writable: isWritable,
+            })),
+            data_base64: ix.data.toString("base64"),
+            program: ix.programId.toBase58(),
+          },
+        ],
+        signers: [from, to],
+      });
+    }).toThrowErrorMatchingSnapshot();
+
+    const gtransaction = GTransaction.create({
+      recentBlockhash: GPublicKey.default.toBase58(),
+      feePayer: from.address,
+      instructions: [
+        {
+          accounts: ix.keys.map(({ pubkey, isSigner, isWritable }) => ({
+            address: pubkey.toBase58(),
+            signer: isSigner,
+            writable: isWritable,
+          })),
+          data_base64: ix.data.toString("base64"),
+          program: ix.programId.toBase58(),
+        },
+      ],
+      signers: [from, to],
+      suppressInvalidSignerError: true,
+    });
+
+    // Sanity check - transaction without signatures shouldn't equal gtransaction with them
+    expect(transaction.serialize({ requireAllSignatures: false })).not.toEqual(
+      GTransaction.toBuffer({ gtransaction })
+    );
+
+    transaction.partialSign(from as unknown as Keypair);
+    // Verify that signed transactions are equal
+    expect(transaction.serialize()).toEqual(
+      GTransaction.toBuffer({ gtransaction })
+    );
+  });
+
+  test("sign with obsolete signers", async () => {
+    // Prepare a simple transfer transaction
+    const from = GKeypair.generate();
+    // We need static to since we match error message against obsolete signer address
+    const to = GKeypair.fromSecretKey(
+      bs58.decode(
+        "2EhQ3g6KrXfPrK8ad5Aa4aCXxKWoGaFD5jRq8ADQxnZ6xr9PxaYj81KtJBseDGudomTPYvEPt2rn8bKpHtcYYtFc"
+      )
+    );
+    const ix = SystemProgram.transfer({
+      fromPubkey: from.publicKey as unknown as PublicKey,
+      toPubkey: to.publicKey as unknown as PublicKey,
+      lamports: 5_000 * 1.5,
+    });
+
+    const transaction = new Transaction({
+      feePayer: from.publicKey as unknown as PublicKey,
+      recentBlockhash: GPublicKey.default.toBase58(),
+    });
+    transaction.add(ix);
+
+    let gtransaction = GTransaction.create({
+      recentBlockhash: GPublicKey.default.toBase58(),
+      feePayer: from.address,
+      instructions: [
+        {
+          accounts: ix.keys.map(({ pubkey, isSigner, isWritable }) => ({
+            address: pubkey.toBase58(),
+            signer: isSigner,
+            writable: isWritable,
+          })),
+          data_base64: ix.data.toString("base64"),
+          program: ix.programId.toBase58(),
+        },
+      ],
+    });
+
+    expect(() => {
+      GTransaction.sign({
+        gtransaction,
+        signers: [from, to],
+      });
+    }).toThrowErrorMatchingSnapshot();
+
+    // Sanity check - verify that serialized versions are equal
+    expect(transaction.serialize({ requireAllSignatures: false })).toEqual(
+      GTransaction.toBuffer({ gtransaction })
+    );
+
+    expect(() => {
+      gtransaction = GTransaction.sign({
+        gtransaction,
+        signers: [from, to],
+        suppressInvalidSignerError: true,
+      });
+    }).not.toThrowError();
+
+    // Add a new signature
+    transaction.partialSign(from as unknown as Keypair);
+
+    // Verify that serialized transactions with more signatures are equal too
+    expect(transaction.serialize()).toEqual(
+      GTransaction.toBuffer({ gtransaction })
+    );
+  });
+
   test("create a transfer transaction", () => {
     const payer = GKeypair.generate();
     const recentBlockhash = "636Lq2zGQDYZ3i6hahVcFWJkY6Jejndy5Qe4gBdukXDi";

--- a/packages/solana-client/src/__tests__/__snapshots__/GTransaction.test.ts.snap
+++ b/packages/solana-client/src/__tests__/__snapshots__/GTransaction.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GTransaction create with signing with obsolete signers 1`] = `"This transaction does not require a signature from: ATBeZdCvKyCbBnk27Mnd5RfcoFUNE5XfQYRTjveiS1cW"`;
+
+exports[`GTransaction sign with obsolete signers 1`] = `"This transaction does not require a signature from: ATBeZdCvKyCbBnk27Mnd5RfcoFUNE5XfQYRTjveiS1cW"`;


### PR DESCRIPTION
Implements suggestion from https://github.com/luma-team/luma/pull/11276#pullrequestreview-1020900823 and changes `.sign` to accept an array of `signers: GKeypair[]` instead of just the secret key. This change shouldn't be incompatible with `luma`, see https://github.com/luma-team/luma/pull/11276/commits/c79b104311558cd3b386b6469725fa8c68b2846e

Example
```ts
    gTransaction = GTransaction.sign({
      gtransaction: gTransaction,
      signers: [from],
    });

    gTransaction = GTransaction.sign({
      gtransaction: gTransaction,
      signers: [from, to],
      suppressInvalidSignerError: true,
    });
```