### PR TITLE
Fix GTransaction.addSignature

### DIFF
--- a/packages/solana-client/src/GTransaction.ts
+++ b/packages/solana-client/src/GTransaction.ts
@@ -256,7 +256,7 @@ export namespace GTransaction {
     // Copy signatures map not to mutate original transaction
     const signatures = gtransaction.signatures.map((sig, index) => {
       return {
-        address,
+        address: sig.address,
         signature:
           index === accountIndex ? bs58.encode(signature) : sig.signature,
       };

--- a/packages/solana-client/src/__tests__/GTransaction.test.ts
+++ b/packages/solana-client/src/__tests__/GTransaction.test.ts
@@ -239,21 +239,21 @@ describe("GTransaction", () => {
           program: GPublicKey.default.toBase58(),
           data_base64: "BQAAAA==",
         },
-      ]
+      ],
     });
 
     gTransaction = GTransaction.sign({
       gtransaction: gTransaction,
-      secretKey: signer1.secretKey,
+      signers: [signer1],
     });
     gTransaction = GTransaction.sign({
       gtransaction: gTransaction,
-      secretKey: signer2.secretKey,
+      signers: [signer2],
     });
 
-    expect(gTransaction.signatures).toHaveLength(2)
-    expect(gTransaction.signatures[0].address).toEqual(signer1.address)
-    expect(gTransaction.signatures[1].address).toEqual(signer2.address)
+    expect(gTransaction.signatures).toHaveLength(2);
+    expect(gTransaction.signatures[0].address).toEqual(signer1.address);
+    expect(gTransaction.signatures[1].address).toEqual(signer2.address);
   });
 
   test("sign", async () => {

--- a/packages/solana-client/src/__tests__/GTransaction.test.ts
+++ b/packages/solana-client/src/__tests__/GTransaction.test.ts
@@ -222,6 +222,40 @@ describe("GTransaction", () => {
     );
   });
 
+  test("sign multiple signatures", async () => {
+    const signer1 = GKeypair.generate();
+    const signer2 = GKeypair.generate();
+    const recentBlockhash = "636Lq2zGQDYZ3i6hahVcFWJkY6Jejndy5Qe4gBdukXDi";
+
+    let gTransaction = GTransaction.create({
+      feePayer: signer1.publicKey.toBase58(),
+      recentBlockhash,
+      instructions: [
+        {
+          accounts: [
+            { address: signer1.publicKey.toBase58(), signer: true },
+            { address: signer2.publicKey.toBase58(), signer: true },
+          ],
+          program: GPublicKey.default.toBase58(),
+          data_base64: "BQAAAA==",
+        },
+      ]
+    });
+
+    gTransaction = GTransaction.sign({
+      gtransaction: gTransaction,
+      secretKey: signer1.secretKey,
+    });
+    gTransaction = GTransaction.sign({
+      gtransaction: gTransaction,
+      secretKey: signer2.secretKey,
+    });
+
+    expect(gTransaction.signatures).toHaveLength(2)
+    expect(gTransaction.signatures[0].address).toEqual(signer1.address)
+    expect(gTransaction.signatures[1].address).toEqual(signer2.address)
+  });
+
   test("sign", async () => {
     // Prepare a simple transfer transaction
     const from = GKeypair.generate();


### PR DESCRIPTION
Fixes the bug where the first call to `GTransaction.addSignature` would corrupt `tx.signatures` by overriding their `address`