### PR TITLE
Add `sideEffect`s false to all `package.json`s

### DIFF
--- a/packages/glow-client/package.json
+++ b/packages/glow-client/package.json
@@ -8,6 +8,7 @@
     "dist/**/*",
     "src/**/*"
   ],
+  "sideEffects": false,
   "scripts": {
     "lint": "eslint . --ext ts --ext tsx --quiet",
     "tsc": "tsc --noEmit",

--- a/packages/glow-react/package.json
+++ b/packages/glow-react/package.json
@@ -8,6 +8,7 @@
     "dist/**/*",
     "src/**/*"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "npm run build:js && npm run build:css",
     "build:js": "tsc",

--- a/packages/solana-client/package.json
+++ b/packages/solana-client/package.json
@@ -13,6 +13,7 @@
     "dist/**/*",
     "src/**/*"
   ],
+  "sideEffects": false,
   "scripts": {
     "lint": "eslint . --ext ts --ext tsx --quiet",
     "tsc": "tsc --noEmit",


### PR DESCRIPTION
This should let `esbuild` tree-shake dead code from these packages, I think. Details about `sideEffects` can be found [here](https://github.com/luma-team/luma/pull/9000).