### PR TITLE
Upgrade `ts-jest` to 29.0.0

### DIFF
--- a/packages/glow-client/jest.config.js
+++ b/packages/glow-client/jest.config.js
@@ -4,17 +4,17 @@ module.exports = {
   testEnvironment: "node",
   moduleFileExtensions: ["ts", "tsx", "js"],
   transform: {
-    "^.+\\.(ts|tsx)$": "ts-jest",
+    "^.+\\.(ts|tsx)$": [
+      "ts-jest",
+      {
+        // This helps the tests run faster
+        // But it skips typechecking, so that should be a different step on CI
+        // https://huafu.github.io/ts-jest/user/config/isolatedModules
+        isolatedModules: true,
+      },
+    ],
   },
   testMatch: ["**/__tests__/*.test.(ts|tsx)"],
   testPathIgnorePatterns: ["./dist", "./node_modules/"],
   collectCoverage: false,
-  globals: {
-    "ts-jest": {
-      // This helps the tests run faster
-      // But it skips typechecking, so that should be a different step on CI
-      // https://huafu.github.io/ts-jest/user/config/isolatedModules
-      isolatedModules: true,
-    },
-  },
 };

--- a/packages/glow-client/package.json
+++ b/packages/glow-client/package.json
@@ -37,7 +37,7 @@
     "jest": "29.0.1",
     "prettier": "2.7.1",
     "rimraf": "3.0.2",
-    "ts-jest": "29.0.0-next.1",
+    "ts-jest": "29.0.0",
     "typescript": "4.8.2"
   },
   "private": false,

--- a/packages/glow-client/package.json
+++ b/packages/glow-client/package.json
@@ -37,7 +37,7 @@
     "jest": "29.0.1",
     "prettier": "2.7.1",
     "rimraf": "3.0.2",
-    "ts-jest": "28.0.8",
+    "ts-jest": "29.0.0-next.1",
     "typescript": "4.8.2"
   },
   "private": false,

--- a/packages/solana-client/jest.config.js
+++ b/packages/solana-client/jest.config.js
@@ -4,17 +4,17 @@ module.exports = {
   testEnvironment: "node",
   moduleFileExtensions: ["ts", "tsx", "js"],
   transform: {
-    "^.+\\.(ts|tsx)$": "ts-jest",
+    "^.+\\.(ts|tsx)$": [
+      "ts-jest",
+      {
+        // This helps the tests run faster
+        // But it skips typechecking, so that should be a different step on CI
+        // https://huafu.github.io/ts-jest/user/config/isolatedModules
+        isolatedModules: true,
+      },
+    ],
   },
   testMatch: ["**/__tests__/*.test.(ts|tsx)"],
   testPathIgnorePatterns: ["./dist", "./node_modules/"],
   collectCoverage: false,
-  globals: {
-    "ts-jest": {
-      // This helps the tests run faster
-      // But it skips typechecking, so that should be a different step on CI
-      // https://huafu.github.io/ts-jest/user/config/isolatedModules
-      isolatedModules: true,
-    },
-  },
 };

--- a/packages/solana-client/package.json
+++ b/packages/solana-client/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-lodash": "7.4.0",
     "jest": "29.0.1",
     "prettier": "2.7.1",
-    "ts-jest": "29.0.0-next.1",
+    "ts-jest": "29.0.0",
     "typescript": "4.8.2"
   },
   "private": false,

--- a/packages/solana-client/package.json
+++ b/packages/solana-client/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-lodash": "7.4.0",
     "jest": "29.0.1",
     "prettier": "2.7.1",
-    "ts-jest": "28.0.8",
+    "ts-jest": "29.0.0-next.1",
     "typescript": "4.8.2"
   },
   "private": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,7 @@ importers:
       luxon: ^2.4.0
       prettier: 2.7.1
       rimraf: 3.0.2
-      ts-jest: 29.0.0-next.1
+      ts-jest: 29.0.0
       tweetnacl: ^1.0.3
       typescript: 4.8.2
       zod: ^3.18.0
@@ -91,7 +91,7 @@ importers:
       jest: 29.0.1
       prettier: 2.7.1
       rimraf: 3.0.2
-      ts-jest: 29.0.0-next.1_wrbav37v4qagvzjukpn2eb27ei
+      ts-jest: 29.0.0_wrbav37v4qagvzjukpn2eb27ei
       typescript: 4.8.2
 
   packages/glow-react:
@@ -144,7 +144,7 @@ importers:
       p-limit: ^3.0.1
       prettier: 2.7.1
       rimraf: ^3.0.2
-      ts-jest: 29.0.0-next.1
+      ts-jest: 29.0.0
       tweetnacl: ^1.0.3
       typescript: 4.8.2
       zod: ^3.18.0
@@ -175,7 +175,7 @@ importers:
       eslint-plugin-lodash: 7.4.0_eslint@8.23.0
       jest: 29.0.1
       prettier: 2.7.1
-      ts-jest: 29.0.0-next.1_wrbav37v4qagvzjukpn2eb27ei
+      ts-jest: 29.0.0_wrbav37v4qagvzjukpn2eb27ei
       typescript: 4.8.2
 
 packages:
@@ -6055,8 +6055,8 @@ packages:
   /tr46/0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
-  /ts-jest/29.0.0-next.1_wrbav37v4qagvzjukpn2eb27ei:
-    resolution: {integrity: sha512-bVo2GDuJiV+cWEYB72tdz2Ips4JDKa04bcKikPULxxUHT4fsoY1zB2zvsrJym18qrFpXyVrIdgJFLfEx2YTkbg==}
+  /ts-jest/29.0.0_wrbav37v4qagvzjukpn2eb27ei:
+    resolution: {integrity: sha512-OxUaigbv5Aon3OMLY9HBtwkGMs1upWE/URrmmVQFzzOcGlEPVuWzGmXUIkWGt/95Dj/T6MGuTrHHGL6kT6Yn8g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
     peerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,7 @@ importers:
       luxon: ^2.4.0
       prettier: 2.7.1
       rimraf: 3.0.2
-      ts-jest: 28.0.8
+      ts-jest: 29.0.0-next.1
       tweetnacl: ^1.0.3
       typescript: 4.8.2
       zod: ^3.18.0
@@ -91,7 +91,7 @@ importers:
       jest: 29.0.1
       prettier: 2.7.1
       rimraf: 3.0.2
-      ts-jest: 28.0.8_wrbav37v4qagvzjukpn2eb27ei
+      ts-jest: 29.0.0-next.1_wrbav37v4qagvzjukpn2eb27ei
       typescript: 4.8.2
 
   packages/glow-react:
@@ -144,7 +144,7 @@ importers:
       p-limit: ^3.0.1
       prettier: 2.7.1
       rimraf: ^3.0.2
-      ts-jest: 28.0.8
+      ts-jest: 29.0.0-next.1
       tweetnacl: ^1.0.3
       typescript: 4.8.2
       zod: ^3.18.0
@@ -175,7 +175,7 @@ importers:
       eslint-plugin-lodash: 7.4.0_eslint@8.23.0
       jest: 29.0.1
       prettier: 2.7.1
-      ts-jest: 28.0.8_wrbav37v4qagvzjukpn2eb27ei
+      ts-jest: 29.0.0-next.1_wrbav37v4qagvzjukpn2eb27ei
       typescript: 4.8.2
 
 packages:
@@ -1363,12 +1363,12 @@ packages:
   /@types/connect/3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 18.7.13
 
   /@types/express-serve-static-core/4.17.29:
     resolution: {integrity: sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==}
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 18.7.13
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
 
@@ -1439,7 +1439,6 @@ packages:
 
   /@types/node/18.7.13:
     resolution: {integrity: sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==}
-    dev: true
 
   /@types/parse-json/4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
@@ -1490,7 +1489,7 @@ packages:
   /@types/ws/7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 18.7.13
 
   /@types/yargs-parser/21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -6056,16 +6055,16 @@ packages:
   /tr46/0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
-  /ts-jest/28.0.8_wrbav37v4qagvzjukpn2eb27ei:
-    resolution: {integrity: sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /ts-jest/29.0.0-next.1_wrbav37v4qagvzjukpn2eb27ei:
+    resolution: {integrity: sha512-bVo2GDuJiV+cWEYB72tdz2Ips4JDKa04bcKikPULxxUHT4fsoY1zB2zvsrJym18qrFpXyVrIdgJFLfEx2YTkbg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
     peerDependencies:
       '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^28.0.0
-      babel-jest: ^28.0.0
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
       esbuild: '*'
-      jest: ^28.0.0
+      jest: ^29.0.0
       typescript: '>=4.3'
     peerDependenciesMeta:
       '@babel/core':
@@ -6081,7 +6080,7 @@ packages:
       esbuild: 0.15.5
       fast-json-stable-stringify: 2.1.0
       jest: 29.0.1
-      jest-util: 28.1.3
+      jest-util: 29.0.1
       json5: 2.2.1
       lodash.memoize: 4.1.2
       make-error: 1.3.6


### PR DESCRIPTION
<img width="1111" alt="Zrzut ekranu 2022-09-8 o 22 22 17" src="https://user-images.githubusercontent.com/1151041/189218469-756d84b6-eb10-4bd2-9d73-071ec6091360.png">

---

It works and lets us _not_ need to add `strict-peer-dependencies=false` to `.npmrc` as per

```
~/Developer/glow-js/packages/glow-client (master) pnpm i      
Scope: all 5 workspace projects
../..                                    | Progress: resolved 416, reused 371, downloaded 0, added 0, done
 ERR_PNPM_PEER_DEP_ISSUES  Unmet peer dependencies

packages/glow-client
└─┬ ts-jest 28.0.8
  └── ✕ unmet peer jest@^28.0.0: found 29.0.1

packages/solana-client
└─┬ ts-jest 28.0.8
  └── ✕ unmet peer jest@^28.0.0: found 29.0.1

hint: If you don't want pnpm to fail on peer dependency issues, add "strict-peer-dependencies=false" to an .npmrc file at the root of your project.
```


---

Change of config prompted by

```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
```