### PR TITLE
Update `loadedAddresses` to be optional in the RPC types

### DIFF
--- a/packages/solana-client/package.json
+++ b/packages/solana-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glow-xyz/solana-client",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "",
   "typings": "dist/types/index.d.ts",
   "exports": {

--- a/packages/solana-client/src/client/rpc-types.ts
+++ b/packages/solana-client/src/client/rpc-types.ts
@@ -89,10 +89,12 @@ export namespace SolanaRpcTypes {
     preBalances: z.array(z.number()),
     preTokenBalances: z.array(TokenBalanceZ).nullable(),
     postTokenBalances: z.array(TokenBalanceZ).nullable(),
-    loadedAddresses: z.object({
-      readonly: z.array(Solana.AddressZ),
-      writable: z.array(Solana.AddressZ),
-    }),
+    loadedAddresses: z
+      .object({
+        readonly: z.array(Solana.AddressZ),
+        writable: z.array(Solana.AddressZ),
+      })
+      .optional(),
   });
   export type TransactionRawMeta = z.infer<typeof TransactionRawMetaZ>;
   export type LoadedAddresses = TransactionRawMeta["loadedAddresses"];

--- a/packages/solana-client/src/transaction/VTransaction.ts
+++ b/packages/solana-client/src/transaction/VTransaction.ts
@@ -156,7 +156,7 @@ export class VTransaction implements TransactionInterface {
       wasLookedUp: false,
     }));
 
-    for (const address of loadedAddresses.writable) {
+    for (const address of loadedAddresses?.writable ?? []) {
       out.push({
         address,
         writable: true,
@@ -164,7 +164,7 @@ export class VTransaction implements TransactionInterface {
         wasLookedUp: true,
       });
     }
-    for (const address of loadedAddresses.readonly) {
+    for (const address of loadedAddresses?.readonly ?? []) {
       out.push({
         address,
         writable: false,


### PR DESCRIPTION
We still want to be able to communicate w/ older versions of Solana.